### PR TITLE
Friendly date literals: today, tomorrow, yesterday

### DIFF
--- a/src/groovy/com/wotifgroup/cucumber/json/CucumberJson.groovy
+++ b/src/groovy/com/wotifgroup/cucumber/json/CucumberJson.groovy
@@ -132,6 +132,12 @@ class CucumberJson {
             return value.substring(1, value.length() - 1)
         } else if (!value.isNumber()) {
             return value
+        } else if (value == "today") {
+            return new Date().format("yyyy-MM-dd'T'HH:mm:ssZ")
+        } else if (value == "tomorrow") {
+            return (new Date() + 1).format("yyyy-MM-dd'T'HH:mm:ssZ")
+        } else if (value == "yesterday") {
+            return (new Date() - 1).format("yyyy-MM-dd'T'HH:mm:ssZ")
         } else {
             if (value.contains(".")) {
                 return value as Float


### PR DESCRIPTION
We have added some "humanized" date literal for use in assertions. 
For example:

And I set the request "dueDate" property to today

will result in a json request value which looks something like:
    2013-04-16T14:34:00+1000

Cheers!
