### PR TITLE
add test that a json string property contains certain text

### DIFF
--- a/src/groovy/com/wotifgroup/cucumber/jsonglue/JsonCommonSteps.groovy
+++ b/src/groovy/com/wotifgroup/cucumber/jsonglue/JsonCommonSteps.groovy
@@ -64,3 +64,11 @@ Then(~'^the response property \"(.*)\" is (\"?.*\"?)$') { String property, Strin
 
     assert (parent."$child" == CucumberJson.parseStringToType(value, jsonBindingUpdater.getDateFormat()))
 }
+
+Then(~/^the response property "(.*)" contains "(.*)"$/) { String property, String value ->
+    path = property.split("\\.")
+    child = path[-1]
+    parent = CucumberJson.parseJsonExpression(path, jsonResponse)
+
+    assert String.valueOf(parent."$child").contains(value)
+}


### PR DESCRIPTION
Only really applicable to string values, so `parseJsonExpression`
does not apply.  Also since it only applies to strings, quoting the
value is mandatory.
